### PR TITLE
handle different subject encodings

### DIFF
--- a/PlancakeEmailParser.php
+++ b/PlancakeEmailParser.php
@@ -106,7 +106,12 @@ class PlancakeEmailParser {
         {
             throw new Exception("Couldn't find the subject of the email");
         }
-        return utf8_encode(iconv_mime_decode($this->rawFields['subject']));
+        $parts = imap_mime_header_decode($this->rawFields['subject']);
+        foreach ($parts as $key => $value) {
+            $text[] = $value->text;
+        }
+        $this->rawFields['subject'] = implode(" ",$text);
+        return utf8_encode($this->rawFields['subject']);
     }
 
     /**


### PR DESCRIPTION
I was experiencing some strange and unreadable subject titles, due to different encodings from different mail sources. For now, I just took the imap_mime_header_decode function. Altough this makes the library dependant on the php imap functions, it seemed to be the cleanest solution.

Feedback is appreciated.
