### PR TITLE
Update PlancakeEmailParser.php

### DIFF
--- a/PlancakeEmailParser.php
+++ b/PlancakeEmailParser.php
@@ -350,8 +350,8 @@ class PlancakeEmailParser {
             throw new Exception("Couldn't find the sender of the email");
         }
     	if (!preg_match('/\"([^\"]+)\" <([^>]+)>/', $this->rawFields['from'], $matches)) {
-			(preg_match('/([^<]+) <([^>]+)>/', $this->rawFields['from'], $matches));
-		}
+		(preg_match('/([^<]+) <([^>]+)>/', $this->rawFields['from'], $matches));
+	}
     }
 
     /**


### PR DESCRIPTION
Added three new functions: `getFrom()`, `getFromName()` and `getFromAddress()`
They can be used to return the sender's display name and e-mail address.

Example:

```
$emailParser = new PlancakeEmailParser($email);

$emailFrom = $emailParser->getFrom();
$emailFromName = $emailParser->getFromName();
$emailFromAddress = $emailParser->getFromAddress();
```

Output:
`$emailFrom`: `"John Doe" <john.doe@foo.com>`
`$emailFromName`: `John Doe`
`$emailFromAddress`: `john.doe@foo.com`
