### PR TITLE
set isImapExtensionAvailable value directly

### DIFF
--- a/PlancakeEmailParser.php
+++ b/PlancakeEmailParser.php
@@ -47,7 +47,7 @@ class PlancakeEmailParser {
      *
      * @var boolean
      */    
-    private $isImapExtensionAvailable = false;
+    private $isImapExtensionAvailable;
     
     /**
      *
@@ -76,9 +76,7 @@ class PlancakeEmailParser {
 
         $this->extractHeadersAndRawBody();
         
-        if (function_exists('imap_open')) {
-            $this->isImapExtensionAvailable = true;
-        }
+        $this->isImapExtensionAvailable = function_exists('imap_open');
     }
 
     private function extractHeadersAndRawBody()


### PR DESCRIPTION
There's no need for the conditional for `function_exists()` in the `__construct()`, since `function_exists()` already returns a boolean (which is what was assigned anyway to isImapExtensionAvailable). So it's safe to just assign this value straight away.
